### PR TITLE
Small fix to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,18 @@ FILES=01-introduction.md 02-starting-out.md 03-types-and-typeclasses.md 04-synta
 all: epubs pdfs
 
 epubs: epub-en
-epub-en: out pandoc metadata.xml
+	-rm -rf en/img/
+
+epub-en: copyimg out pandoc metadata.xml
 	$(DOCGEN) $(DOCGEN_FLAGS) --epub-metadata=metadata.xml -o out/lyah-en.epub $(addprefix en/, $(FILES))
 
 pdfs: pdf-en
+
 pdf-en: out en pandoc pdflatex 
 	$(DOCGEN) $(DOCGEN_FLAGS) -o out/lyah-en.pdf $(addprefix en/, $(FILES))
+
+copyimg:
+	-cp -rf img/ en/
 
 out:
 	mkdir out


### PR DESCRIPTION
I get this error when I do make
pandoc: en/img/bigtree.png: openBinaryFile: does not exist (No such file or directory)
make: **\* [epub-en] Error 1

Fixing all image links I get output of epub file (i.e. _img/ -> ../img_), but an error for pdf file
pandoc: Error producing PDF from TeX source.
! Package pdftex.def Error: File `../img/bird.png' not found.

I think the issue is because of pdflatex fails to parse relative path...
The changes in Makefile I think is the most minimal way to fix the build issue..
