### PR TITLE
Fixed makefile settings to work with pandoc 2.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCGEN=pandoc
-DOCGEN_FLAGS=--toc -S
+DOCGEN_FLAGS=--toc -smart
 
 FILES=01-introduction.md 02-starting-out.md 03-types-and-typeclasses.md 04-syntax-in-functions.md 05-recursion.md 06-higher-order-functions.md 07-modules.md 08-making-our-own-types-and-typeclasses.md 09-input-and-output.md 10-functionally-solving-problems.md 11-functors-applicative-functors-and-monoids.md 12-a-fistful-of-monads.md 13-for-a-few-monads-more.md 14-zippers.md
 EPUB_STYLESHEET=epub-stylesheet.css
@@ -11,7 +11,7 @@ epubs: epub-en
 	-rm -rf en/img/
 
 epub-en: copyimg out pandoc metadata.xml
-	$(DOCGEN) $(DOCGEN_FLAGS) --epub-metadata=metadata.xml --epub-stylesheet=$(EPUB_STYLESHEET) --epub-embed-font=$(EPUB_CODE_FONT) -o out/lyah-en.epub --epub-cover-image=img/lyah.jpg title.txt $(addprefix en/, $(FILES))
+	$(DOCGEN) $(DOCGEN_FLAGS) --epub-metadata=metadata.xml --css=$(EPUB_STYLESHEET) --epub-embed-font=$(EPUB_CODE_FONT) -o out/lyah-en.epub --epub-cover-image=img/lyah.jpg title.txt $(addprefix en/, $(FILES))
 
 pdfs: pdf-en
 


### PR DESCRIPTION
running `make all`  produced these errors
```
...
--smart/-S has been removed.  Use +smart or -smart extension instead.
For example: pandoc -f markdown+smart -t markdown-smart.
--epub-stylesheet has been removed. Use --css instead.
```

This patch updates the `make all` script to function with Pandoc 2.0+