### PR TITLE
Typo in state monad section

### DIFF
--- a/en/13-for-a-few-monads-more.md
+++ b/en/13-for-a-few-monads-more.md
@@ -1073,10 +1073,10 @@ easy to wrap them into a `State` wrapper. Watch:
 import Control.Monad.State
 
 pop :: State Stack Int
-pop = State $ \(x:xs) -> (x,xs)
+pop = state $ \(x:xs) -> (x,xs)
 
 push :: Int -> State Stack ()
-push a = State $ \xs -> ((),a:xs)
+push a = state $ \xs -> ((),a:xs)
 ~~~~
 
 `pop` is already a stateful computation and `push` takes an `Int` and returns


### PR DESCRIPTION
After trying to run one of the examples, I believe the that there is a typo in the state monad section.

We should be using the `state` function (lower case) rather than `State` which would infer a type constructor (upper case).

Here is the docs on the `state` function which we are using:

http://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-State-Lazy.html#g:1