### PR TITLE
Fix span code example

### DIFF
--- a/en/07-modules.md
+++ b/en/07-modules.md
@@ -334,7 +334,7 @@ contain if it were called with the same predicate and the same list. The
 second list contains the part of the list that would have been dropped.
 
 ~~~~ {.haskell:ghci name="code"}
-ghci> let (fw, rest) = span (/=' ') "This is a sentence" in "First word:" ++ fw ++ ", the rest:" ++ rest
+ghci> let (fw, rest) = span (/=' ') "This is a sentence" in "First word: " ++ fw ++ ", the rest:" ++ rest
 "First word: This, the rest: is a sentence"
 ~~~~
 


### PR DESCRIPTION
The span code example is not correct:

In the book:
```
ghci> let (fw, rest) = span (/=' ') "This is a sentence" in "First word:" ++ fw ++ ", the rest:" ++ rest  
"First word: This, the rest: is a sentence"  
```

in ghci:
```
Prelude> let (fw, rest) = span (/=' ') "This is a sentence" in "First word:" ++ fw ++ ", the rest:" ++ rest
"First word:This, the rest: is a sentence"
```

This miniscule change fixes this.