### PR TITLE
Fixed links to images, so that they appear when browsing the .md files on GitHub

### DIFF
--- a/en/01-introduction.md
+++ b/en/01-introduction.md
@@ -45,6 +45,7 @@ So what's Haskell?
 ------------------
 
 ![fx](../img/fx.png) 
+
 Haskell is a *purely
 functional programming language*. In imperative languages you get things
 done by giving the computer a sequence of tasks and then it executes
@@ -70,6 +71,7 @@ deduce (and even prove) that a function is correct and then build more
 complex functions by gluing simple functions together.
 
 ![lazy](../img/lazy.png) 
+
 Haskell is *lazy*. That
 means that unless specifically told otherwise, Haskell won't execute
 functions and calculate things until it's really forced to show you a
@@ -95,6 +97,7 @@ initial data and efficiently transform and mend it so it resembles what
 you want at the end.
 
 ![boat](../img/boat.png) 
+
 Haskell is *statically
 typed*. When you compile your program, the compiler knows which piece of
 code is a number, which is a string and so on. That means that a lot of

--- a/en/01-introduction.md
+++ b/en/01-introduction.md
@@ -20,7 +20,7 @@ came falling into place. So this is an attempt at adding another useful
 resource for learning Haskell so you have a bigger chance of finding one
 you like.
 
-![bird](img/bird.png)
+![bird](../img/bird.png)
 
 This tutorial is aimed at people who have experience in imperative
 programming languages (C, C++, Java, Python …) but haven't programmed in
@@ -44,7 +44,8 @@ you to think differently, which brings us to the next section …
 So what's Haskell?
 ------------------
 
-![fx](img/fx.png) Haskell is a *purely
+![fx](../img/fx.png) 
+Haskell is a *purely
 functional programming language*. In imperative languages you get things
 done by giving the computer a sequence of tasks and then it executes
 them. While executing them, it can change state. For instance, you set
@@ -68,7 +69,8 @@ reason about the program's behavior, but it also allows you to easily
 deduce (and even prove) that a function is correct and then build more
 complex functions by gluing simple functions together.
 
-![lazy](img/lazy.png) Haskell is *lazy*. That
+![lazy](../img/lazy.png) 
+Haskell is *lazy*. That
 means that unless specifically told otherwise, Haskell won't execute
 functions and calculate things until it's really forced to show you a
 result. That goes well with referential transparency and it allows you
@@ -92,7 +94,8 @@ way when you want something from a lazy language you can just take some
 initial data and efficiently transform and mend it so it resembles what
 you want at the end.
 
-![boat](img/boat.png) Haskell is *statically
+![boat](../img/boat.png) 
+Haskell is *statically
 typed*. When you compile your program, the compiler knows which piece of
 code is a number, which is a string and so on. That means that a lot of
 possible errors are caught at compile time. If you try to add together a

--- a/en/02-starting-out.md
+++ b/en/02-starting-out.md
@@ -4,7 +4,9 @@ Starting Out
 Ready, set, go!
 ---------------
 
-![egg](img/startingout.png) Alright, let's get
+![egg](../img/startingout.png)
+
+Alright, let's get
 started! If you're the sort of horrible person who doesn't read
 introductions to things and you skipped it, you might want to read the
 last section in the introduction anyway because it explains what you
@@ -118,7 +120,9 @@ them. As you've seen, we call it by sandwiching it between them. This is
 what we call an *infix* function. Most functions that aren't used with
 numbers are *prefix* functions. Let's take a look at them.
 
-![phoen](img/ringring.png) Functions are
+![phone](../img/ringring.png) 
+
+Functions are
 usually prefix so from now on we won't explicitly state that a function
 is of the prefix form, we'll just assume it. In most imperative
 languages functions are called by writing the function name and then
@@ -264,7 +268,7 @@ doubleSmallNumber x = if x > 100
                         else x*2
 ~~~~
 
-![this is you](img/baby.png)
+![this is you](../img/baby.png)
 
 Right here we introduced Haskell's if statement. You're probably
 familiar with if statements from other languages. The difference between
@@ -310,7 +314,9 @@ O'Brien!"` can be used interchangeably.
 An intro to lists
 -----------------
 
-![BUY A DOG](img/list.png) Much like shopping
+![BUY A DOG](../img/list.png) 
+
+Much like shopping
 lists in the real world, lists in Haskell are very useful. It's the most
 used data structure and it can be used in a multitude of different ways
 to model and solve a whole bunch of problems. Lists are SO awesome. In
@@ -468,7 +474,7 @@ ghci> init [5,4,3,2,1]
 
 If we think of a list as a monster, here's what's what.
 
-![list monster](img/listmonster.png)
+![list monster](../img/listmonster.png)
 
 But what happens if we try to get the head of an empty list?
 
@@ -580,7 +586,9 @@ look at more list functions [later](#data-list)
 Texas ranges
 ------------
 
-![draw](img/cowboy.png) What if we want a list
+![draw](../img/cowboy.png) 
+
+What if we want a list
 of all numbers between 1 and 20? Sure, we could just type them all out
 but obviously that's not a solution for gentlemen who demand excellence
 from their programming languages. Instead, we'll use ranges. Ranges are
@@ -676,12 +684,14 @@ some number of the same element in a list. `replicate 3 10` returns
 I'm a list comprehension
 ------------------------
 
-![frog](img/kermit.png) If you've ever taken a
+![frog](../img/kermit.png) 
+
+If you've ever taken a
 course in mathematics, you've probably run into *set comprehensions*.
 They're normally used for building more specific sets out of general
 sets. A basic comprehension for a set that contains the first ten even
 natural numbers is ![set
-notation](img/setnotation.png). The part before
+notation](../img/setnotation.png). The part before
 the pipe is called the output function, `x` is the variable, `N` is the
 input set and `x <= 10` is the predicate. That means that the set
 contains the doubles of all natural numbers that satisfy the predicate. You
@@ -832,7 +842,7 @@ lines, especially if they're nested.
 Tuples
 ------
 
-![tuples](img/tuple.png)
+![tuples](../img/tuple.png)
 
 In some ways, tuples are like lists — they are a way to store several
 values into a single value. However, there are a few fundamental
@@ -949,7 +959,7 @@ ghci> zip [1..] ["apple", "orange", "cherry", "mango"]
 [(1,"apple"),(2,"orange"),(3,"cherry"),(4,"mango")]
 ~~~~
 
-![look at meee](img/pythag.png)
+![look at meee](../img/pythag.png)
 
 Here's a problem that combines tuples and list comprehensions: which
 right triangle that has integers for all sides and all sides equal to or

--- a/en/03-types-and-typeclasses.md
+++ b/en/03-types-and-typeclasses.md
@@ -44,6 +44,7 @@ ghci> :t 4 == 5
 ~~~~
 
 ![bomb](../img/bomb.png) 
+
 Here we see that doing `:t`
 on an expression prints out the expression followed by `::` and its type.
 `::` is read as "has type of". Explicit types are always denoted with the

--- a/en/03-types-and-typeclasses.md
+++ b/en/03-types-and-typeclasses.md
@@ -4,7 +4,7 @@ Types and Typeclasses
 Believe the type
 ----------------
 
-![moo](img/cow.png)
+![moo](../img/cow.png)
 
 Previously we mentioned that Haskell has a static type system. The type
 of every expression is known at compile time, which leads to safer code.
@@ -43,7 +43,8 @@ ghci> :t 4 == 5
 4 == 5 :: Bool
 ~~~~
 
-![bomb](img/bomb.png) Here we see that doing `:t`
+![bomb](../img/bomb.png) 
+Here we see that doing `:t`
 on an expression prints out the expression followed by `::` and its type.
 `::` is read as "has type of". Explicit types are always denoted with the
 first letter in capital case. `'a'`, as it would seem, has a type of `Char`.
@@ -164,7 +165,9 @@ ghci> :t head
 head :: [a] -> a
 ~~~~
 
-![box](img/box.png) Hmmm! What is this `a`? Is it
+![box](../img/box.png) 
+
+Hmmm! What is this `a`? Is it
 a type? Remember that we previously stated that types are written in
 capital case, so it can't exactly be a type. Because it's not in capital
 case it's actually a *type variable*. That means that `a` can be of any
@@ -198,7 +201,7 @@ return value's type are the same.
 Typeclasses 101
 ---------------
 
-![class](img/classes.png)
+![class](../img/classes.png)
 
 A typeclass is a sort of interface that defines some behavior. If a type
 is a part of a typeclass, that means that it supports and implements the

--- a/en/04-syntax-in-functions.md
+++ b/en/04-syntax-in-functions.md
@@ -4,7 +4,7 @@ Syntax in Functions
 Pattern matching
 ----------------
 
-![four!](img/pattern.png)
+![four!](../img/pattern.png)
 
 This chapter will cover some of Haskell's cool syntactic constructs and
 we'll start with pattern matching. Pattern matching consists of
@@ -292,7 +292,7 @@ because of the nature of lists, you can't do that.
 Guards, guards!
 ---------------
 
-![guards](img/guards.png)
+![guards](../img/guards.png)
 
 Whereas patterns are a way of making sure a value conforms to some form
 and deconstructing it, guards are a way of testing whether some property
@@ -545,7 +545,7 @@ cylinder r h =
     in  sideArea + 2 * topArea
 ~~~~
 
-![let it be](img/letitbe.png)
+![let it be](../img/letitbe.png)
 
 The form is `let <bindings> in <expression>`. The names that you
 define in the *let* part are accessible to the expression after the *in*
@@ -652,7 +652,7 @@ its name and type declaration and to some that's more readable.
 Case expressions
 ----------------
 
-![case](img/case.png)
+![case](../img/case.png)
 
 Many imperative languages (C, C++, Java, etc.) have case syntax and if
 you've ever programmed in them, you probably know what it's about. It's

--- a/en/05-recursion.md
+++ b/en/05-recursion.md
@@ -6,7 +6,7 @@ Recursion
 Hello recursion!
 ----------------
 
-![SOVIET RUSSIA](img/recursion.png)
+![SOVIET RUSSIA](../img/recursion.png)
 
 We mention recursion briefly in the previous chapter. In this chapter,
 we'll take a closer look at recursion, why it's important to Haskell and
@@ -111,7 +111,7 @@ maximum' (x:xs) = max x (maximum' xs)
 How's that for elegant! In essence, the maximum of a list is the max of
 the first element and the maximum of the tail.
 
-![max](img/maxs.png)
+![max](../img/maxs.png)
 
 A few more recursive functions
 ------------------------------
@@ -158,7 +158,7 @@ take' _ []     = []
 take' n (x:xs) = x : take' (n-1) xs
 ~~~~
 
-![painter](img/painter.png)
+![painter](../img/painter.png)
 
 The first pattern specifies that if we try to take a 0 or negative
 number of elements, we get an empty list. Notice that we're using `_` to
@@ -258,7 +258,7 @@ Therefore, let's implement it here, even though implementing quicksort
 in Haskell is considered really cheesy because everyone does it to
 showcase how elegant Haskell is.
 
-![quickman](img/quickman.png)
+![quickman](../img/quickman.png)
 
 So, the type signature is going to be
 `quicksort :: (Ord a) => [a] -> [a]`.
@@ -306,7 +306,7 @@ Eventually, we'll break it up so much that we reach empty lists and an
 empty list is already sorted in a way, by virtue of being empty. Here's
 an illustration:
 
-![quicksort](img/quicksort.png)
+![quicksort](../img/quicksort.png)
 
 An element that is in place and won't move anymore is represented in
 orange. If you read them from left to right, you'll see the sorted list.
@@ -331,7 +331,7 @@ element of the list times the product of the rest of the list. The
 length of a list is one plus the length of the tail of the list.
 Ekcetera, ekcetera ...
 
-![brain](img/brain.png)
+![brain](../img/brain.png)
 
 Of course, these also have edge cases. Usually the edge case is some
 scenario where a recursive application doesn't make sense. When dealing

--- a/en/06-higher-order-functions.md
+++ b/en/06-higher-order-functions.md
@@ -1,7 +1,7 @@
 Higher order functions
 ======================
 
-![sun](img/sun.png)
+![sun](../img/sun.png)
 
 Haskell functions can take functions as parameters and return functions
 as return values. A function that does either of those is called a
@@ -37,7 +37,7 @@ ghci> (max 4) 5
 5
 ~~~~
 
-![haskell curry](img/curry.png)
+![haskell curry](../img/curry.png)
 
 Putting a space between two things is simply **function application**.
 The space is sort of like an operator and it has the highest precedence.
@@ -176,7 +176,7 @@ applyTwice :: (a -> a) -> a -> a
 applyTwice f x = f (f x)
 ~~~~
 
-![rocktopus](img/bonus.png)
+![rocktopus](../img/bonus.png)
 
 First of all, notice the type declaration. Before, we didn't need
 parentheses because `->` is naturally right-associative. However, here,
@@ -414,7 +414,7 @@ quicksort (x:xs) =
     in  smallerSorted ++ [x] ++ biggerSorted
 ~~~~
 
-![map](img/map.png)
+![map](../img/map.png)
 
 Mapping and filtering is the bread and butter of every functional
 programmer's toolbox. Uh. It doesn't matter if you do it with the `map`
@@ -571,7 +571,7 @@ So that's like writing `(4*) 5` or just `4 * 5`.
 Lambdas
 -------
 
-![lambda](img/lambda.png)
+![lambda](../img/lambda.png)
 
 Lambdas are basically anonymous functions that are used because we need
 some functions only once. Normally, we make a lambda with the sole
@@ -596,7 +596,7 @@ Lambdas are expressions, that's why we can just pass them like that. The
 expression `(\xs -> length xs > 15)` returns a function that tells us
 whether the length of the list passed to it is greater than 15.
 
-![lamb](img/lamb.png)
+![lamb](../img/lamb.png)
 
 People who are not well acquainted with how currying and partial
 application works often use lambdas where they don't need to. For
@@ -666,7 +666,7 @@ passed on to a function as a parameter.
 Only folds and horses
 ---------------------
 
-![folded bird](img/origami.png)
+![folded bird](../img/origami.png)
 
 Back when we were dealing with recursion, we noticed a theme throughout
 many of the recursive functions that operated on lists. Usually, we'd
@@ -706,7 +706,7 @@ ghci> sum' [3,5,2,1]
 11
 ~~~~
 
-![foldl](img/foldl.png)
+![foldl](../img/foldl.png)
 
 Let's take an in-depth look into how this fold happens.
 `\acc x -> acc + x` is the binary function.
@@ -792,7 +792,7 @@ It would be `map' f xs = foldl (\acc x -> acc ++ [f x]) [] xs`, but the
 thing is that the `++` function is much more expensive than `:`, so we
 usually use right folds when we're building up new lists from a list.
 
-![fold this up!](img/washmachine.png)
+![fold this up!](../img/washmachine.png)
 
 If you reverse a list, you can do a right fold on it just like you would
 have done a left fold and vice versa. Sometimes you don't even have to
@@ -933,7 +933,7 @@ Alright, next up, we'll take a look at the `$` function, also called
 f $ x = f x
 ~~~~
 
-![dollar](img/dollar.png)
+![dollar](../img/dollar.png)
 
 What the heck? What is this useless operator? It's just function
 application! Well, almost, but not quite! Whereas normal function
@@ -981,7 +981,7 @@ Function composition
 --------------------
 
 In mathematics, function composition is defined like this:
-![ (f . g)(x) = f(g(x))](img/composition.png), meaning that
+![ (f . g)(x) = f(g(x))](../img/composition.png), meaning that
 composing two functions produces a new function that, when called with a
 parameter, say, *x* is the equivalent of calling *g* with the parameter
 *x* and then calling the *f* with that result.
@@ -994,7 +994,7 @@ function composition with the `.` function, which is defined like so:
 f . g = \x -> f (g x)
 ~~~~
 
-![notes](img/notes.png)
+![notes](../img/notes.png)
 
 Mind the type declaration. `f` must take as its parameter a value that has
 the same type as `g`'s return value. So the resulting function takes a

--- a/en/07-modules.md
+++ b/en/07-modules.md
@@ -4,7 +4,7 @@ Modules
 Loading modules
 ---------------
 
-![modules](img/modules.png)
+![modules](../img/modules.png)
 
 A Haskell module is a collection of related functions, types and
 typeclasses. A Haskell program is a collection of modules where the main
@@ -182,7 +182,7 @@ When we transpose these three lists, the third powers are then in the
 first row, the second powers in the second one and so on. Mapping `sum` to
 that produces our desired result.
 
-![shopping lists](img/legolists.png)
+![shopping lists](../img/legolists.png)
 
 `foldl'` and `foldl1'` are stricter versions of their respective lazy
 incarnations. When using lazy folds on really big lists, you might often
@@ -767,7 +767,7 @@ with *By* functions that take an ordering function, you usually do
 Data.Char
 ---------
 
-![lego char](img/legochar.png)
+![lego char](../img/legochar.png)
 
 The `Data.Char` module does what its name suggests. It exports functions
 that deal with characters. It's also helpful when filtering and mapping
@@ -1063,7 +1063,7 @@ ghci> findKey "wilma" phoneBook
 Nothing
 ~~~~
 
-![legomap](img/legomap.png)
+![legomap](../img/legomap.png)
 
 Works like a charm! If we have the girl's phone number, we `Just` get the
 number, otherwise we get `Nothing`.
@@ -1296,7 +1296,7 @@ list of functions in the
 Data.Set
 --------
 
-![legosets](img/legosets.png)
+![legosets](../img/legosets.png)
 
 The `Data.Set` module offers us, well, sets. Like sets from mathematics.
 Sets are kind of like a cross between lists and maps. All the elements
@@ -1433,7 +1433,7 @@ preserves the ordering of the list's elements, while `setNub` does not.
 Making our own modules
 ----------------------
 
-![making modules](img/making_modules.png)
+![making modules](../img/making_modules.png)
 
 We've looked at some cool modules so far, but how do we make our own
 module? Almost every programming language enables you to split your code

--- a/en/08-making-our-own-types-and-typeclasses.md
+++ b/en/08-making-our-own-types-and-typeclasses.md
@@ -31,7 +31,7 @@ this:
 data Int = -2147483648 | -2147483647 | ... | -1 | 0 | 1 | 2 | ... | 2147483647
 ~~~~
 
-![caveman](img/caveman.png)
+![caveman](../img/caveman.png)
 
 The first and last value constructors are the minimum and maximum
 possible values of `Int`. It's not actually defined like this, the
@@ -252,7 +252,7 @@ uses our module can't pattern match against the value constructors.
 Record syntax
 -------------
 
-![record](img/record.png)
+![record](../img/record.png)
 
 OK, we've been tasked with creating a data type that describes a person.
 The info that we want to store about that person is: first name, last
@@ -397,7 +397,7 @@ type we've already met is implemented.
 data Maybe a = Nothing | Just a
 ~~~~
 
-![yeti](img/yeti.png)
+![yeti](../img/yeti.png)
 
 The `a` here is the type parameter. And because there's a type parameter
 involved, we call `Maybe` a type constructor. Depending on what we want
@@ -510,7 +510,7 @@ ghci> :t Car "Ford" "Mustang" "nineteen sixty seven"
 Car "Ford" "Mustang" "nineteen sixty seven" :: Car [Char] [Char] [Char]
 ~~~~
 
-![meekrat](img/meekrat.png)
+![meekrat](../img/meekrat.png)
 
 In real life though, we'd end up using `Car String String Int` most of the
 time and so it would seem that parameterizing the `Car` type isn't really
@@ -609,7 +609,7 @@ Vector 148 666 222
 Derived instances
 -----------------
 
-![gob](img/gob.png)
+![gob](../img/gob.png)
 
 In the [Typeclasses 101](#typeclasses-101) section,
 we explained the basics of typeclasses. We explained that a typeclass is
@@ -883,7 +883,7 @@ library defines `String` as a synonym for `[Char]`.
 
 ~~~~
 
-![chicken](img/chicken.png)
+![chicken](../img/chicken.png)
 
 We've introduced the *type* keyword. The keyword might be misleading to
 some, because we're not actually making anything new (we did that with
@@ -1140,7 +1140,7 @@ about the failure in our result type.
 Recursive data structures
 -------------------------
 
-![the fonz](img/thefonz.png)
+![the fonz](../img/thefonz.png)
 
 As we've seen, a constructor in an algebraic data type can have several
 (or none at all) fields and each field must be of some concrete type.
@@ -1272,7 +1272,7 @@ match for stuff like that, normal prefix constructors or stuff like `8` or
 `'a'`, which are basically constructors for the numeric and character
 types, respectively.
 
-![binary search tree](img/binarytree.png)
+![binary search tree](../img/binarytree.png)
 
 Now, we're going to implement a *binary search tree*. If you're not
 familiar with binary search trees from languages like C, here's what
@@ -1414,7 +1414,7 @@ boolean values and weekday enumerations to binary search trees and more!
 Typeclasses 102
 ---------------
 
-![tweet](img/trafficlight.png)
+![tweet](../img/trafficlight.png)
 
 So far, we've learned about some of the standard Haskell typeclasses and
 we've seen which types are in them. We've also learned how to
@@ -1683,7 +1683,7 @@ you the type declaration of a function. I think that's pretty cool.
 A yes-no typeclass
 ------------------
 
-![yesno](img/yesno.png)
+![yesno](../img/yesno.png)
 
 In JavaScript and some other weakly typed languages, you can put almost
 anything inside an if expression. For example, you can do all of the
@@ -1853,7 +1853,7 @@ class Functor f where
     fmap :: (a -> b) -> f a -> f b
 ~~~~
 
-![I AM FUNCTOOOOR!!!](img/functor.png)
+![I AM FUNCTOOOOR!!!](../img/functor.png)
 
 Alright. We see that it defines one function, `fmap`, and doesn't provide
 any default implementation for it. The type of `fmap` is interesting. In
@@ -2041,7 +2041,7 @@ chapters, we'll also take a look at some laws that apply for functors.
 Kinds and some type-foo
 -----------------------
 
-![TYPE FOO MASTER](img/typefoo.png)
+![TYPE FOO MASTER](../img/typefoo.png)
 
 Type constructors take other types as parameters to eventually produce
 concrete types. That kind of reminds me of functions, which take values

--- a/en/09-input-and-output.md
+++ b/en/09-input-and-output.md
@@ -1511,8 +1511,7 @@ Take salad out of the oven
 Command line arguments
 ----------------------
 
-![COMMAND LINE ARGUMENTS!!!
-ARGH](../img/arguments.png)
+![COMMAND LINE ARGUMENTS!!! ARGH](../img/arguments.png)
 
 Dealing with command line arguments is pretty much a necessity if you
 want to make a script or application that runs on a terminal. Luckily,
@@ -1818,8 +1817,7 @@ to use exceptions, which we will meet soon.
 Randomness
 ----------
 
-![this picture is the ultimate source of randomness and
-wackiness](../img/random.png)
+![this picture is the ultimate source of randomness and wackiness](../img/random.png)
 
 Many times while programming, you need to get some random data. Maybe
 you're making a game where a die needs to be thrown or you need to
@@ -2244,8 +2242,7 @@ provides us with a function that we can reuse easily.
 Bytestrings
 -----------
 
-![like normal string, only they byte ... what a pedestrian pun this
-is](../img/chainchomp.png)
+![like normal string, only they byte ... what a pedestrian pun this is](../img/chainchomp.png)
 
 Lists are a cool and useful data structure. So far, we've used them
 pretty much everywhere. There are a multitude of functions that operate
@@ -2498,9 +2495,7 @@ ghci> head []
 *** Exception: Prelude.head: empty list
 ~~~~
 
-![Stop right there, criminal scum! Nobody breaks the law on my watch!
-Now pay your fine or it's off to
-jail.](../img/police.png)
+![Stop right there, criminal scum! Nobody breaks the law on my watch! Now pay your fine or it's off to jail.](../img/police.png)
 
 Pure code can throw exceptions, but they can only be caught in the
 I/O part of our code (when we're inside a *do* block that goes into

--- a/en/09-input-and-output.md
+++ b/en/09-input-and-output.md
@@ -1,7 +1,7 @@
 Input and Output
 ================
 
-![poor dog](img/dognap.png)
+![poor dog](../img/dognap.png)
 
 We've mentioned that Haskell is a purely functional language. Whereas in
 imperative languages you usually get things done by giving the computer
@@ -41,7 +41,7 @@ while efficiently communicating with the outside world.
 Hello, world!
 -------------
 
-![HELLO!](img/helloworld.png)
+![HELLO!](../img/helloworld.png)
 
 Up until now, we've always loaded our functions into GHCI to test them
 out and play with them. We've also explored the standard library
@@ -146,7 +146,7 @@ ghci> :t getLine
 getLine :: IO String
 ~~~~
 
-![luggage](img/luggage.png)
+![luggage](../img/luggage.png)
 
 Aha, o-kay. `getLine` is an I/O action that contains a result type of
 `String`. That makes sense, because it will wait for the user to input
@@ -755,7 +755,7 @@ performed, print beautiful poetry to your terminal.
 Files and streams
 -----------------
 
-![streams](img/streams.png)
+![streams](../img/streams.png)
 
 `getChar` is an I/O action that reads a single character from the
 terminal. `getLine` is an I/O action that reads a line from the terminal.
@@ -1128,7 +1128,7 @@ type FilePath = String
 data IOMode = ReadMode | WriteMode | AppendMode | ReadWriteMode
 ~~~~
 
-![A FILE IN A CAKE!!!](img/file.png)
+![A FILE IN A CAKE!!!](../img/file.png)
 
 Just like our type that represents the seven possible values for the
 days of the week, this type is an enumeration that represents what we
@@ -1213,7 +1213,7 @@ withFile' path mode f = do
     return result
 ~~~~
 
-![butter toast](img/edd.png)
+![butter toast](../img/edd.png)
 
 We know the result will be an I/O action so we can just start off with a
 *do*. First we open the file and get a `handle` from it. Then, we apply
@@ -1512,7 +1512,7 @@ Command line arguments
 ----------------------
 
 ![COMMAND LINE ARGUMENTS!!!
-ARGH](img/arguments.png)
+ARGH](../img/arguments.png)
 
 Dealing with command line arguments is pretty much a necessity if you
 want to make a script or application that runs on a terminal. Luckily,
@@ -1760,7 +1760,7 @@ remove [fileName, numberString] = do
     renameFile tempName fileName
 ~~~~
 
-![fresh baked salad](img/salad.png)
+![fresh baked salad](../img/salad.png)
 
 To summarize our solution: we made a dispatch association that maps from
 commands to functions that take some command line arguments and return
@@ -1819,7 +1819,7 @@ Randomness
 ----------
 
 ![this picture is the ultimate source of randomness and
-wackiness](img/random.png)
+wackiness](../img/random.png)
 
 Many times while programming, you need to get some random data. Maybe
 you're making a game where a die needs to be thrown or you need to
@@ -2166,7 +2166,7 @@ askForNumber gen = do
         askForNumber newGen
 ~~~~
 
-![jack of diamonds](img/jackofdiamonds.png)
+![jack of diamonds](../img/jackofdiamonds.png)
 
 We make a function `askForNumber`, which takes a random number generator
 and returns an I/O action that will prompt the user for a number and
@@ -2245,7 +2245,7 @@ Bytestrings
 -----------
 
 ![like normal string, only they byte ... what a pedestrian pun this
-is](img/chainchomp.png)
+is](../img/chainchomp.png)
 
 Lists are a cool and useful data structure. So far, we've used them
 pretty much everywhere. There are a multitude of functions that operate
@@ -2450,7 +2450,7 @@ bytestrings if the performance is not satisfactory.
 Exceptions
 ----------
 
-![timberr!!!!](img/timber.png)
+![timberr!!!!](../img/timber.png)
 
 All languages have procedures, functions, and pieces of code that might
 fail in some way. That's just a fact of life. Different languages have
@@ -2500,7 +2500,7 @@ ghci> head []
 
 ![Stop right there, criminal scum! Nobody breaks the law on my watch!
 Now pay your fine or it's off to
-jail.](img/police.png)
+jail.](../img/police.png)
 
 Pure code can throw exceptions, but they can only be caught in the
 I/O part of our code (when we're inside a *do* block that goes into
@@ -2598,7 +2598,7 @@ result is an I/O action that will either act the same as the first
 parameter or it will do what the handler tells it if the first I/O
 action throws an exception.
 
-![non sequitor](img/puppy.png)
+![non sequitor](../img/puppy.png)
 
 If you're familiar with *try-catch* blocks in languages like Java or
 Python, the `catch` function is similar to them. The first parameter is

--- a/en/10-functionally-solving-problems.md
+++ b/en/10-functionally-solving-problems.md
@@ -38,7 +38,7 @@ stack. When you reach the end of the expression, you should be left with
 a single number if the expression was well-formed and that number
 represents the result.
 
-![this expression](img/rpn.png)
+![this expression](../img/rpn.png)
 
 Let's go over the expression `10 4 3 + 2 * -` together! First we push `10`
 on to the stack and the stack is now `10`. The next item is `4`, so we push
@@ -68,7 +68,7 @@ something like `solveRPN :: (Num a) => String -> a`.
 > and then write it down. In Haskell, a function's type declaration tells
 > us a whole lot about the function, due to the very strong type system.
 
-![HA HA HA](img/calculator.png)
+![HA HA HA](../img/calculator.png)
 
 Cool. When implementing a solution to a problem in Haskell, it's also
 good to think back on how you did it by hand and maybe try to see if you
@@ -282,7 +282,7 @@ the optimal path to take so that you get to London as fast as you can!
 You start on the left side and can either cross to the other main road
 or go forward.
 
-![Heathrow - London](img/roads.png)
+![Heathrow - London](../img/roads.png)
 
 As you can see in the picture, the shortest path from Heathrow to London
 in this case is to start on main road B, cross over, go forward on A,
@@ -343,7 +343,7 @@ of say that we're pretty sure.
 That's not a good solution then. Here's a simplified picture of our road
 system:
 
-![roads](img/roads_simple.png)
+![roads](../img/roads_simple.png)
 
 Alright, can you figure out what the shortest path to the first
 crossroads (the first blue dot on A, marked *A1*) on road A is? That's
@@ -540,7 +540,7 @@ roadStep (pathA, pathB) (Section a b c) =
     in  (newPathToA, newPathToB)
 ~~~~
 
-![this is you](img/guycar.png)
+![this is you](../img/guycar.png)
 
 What's going on here? First, calculate the optimal price on road A based
 on the best so far on A and we do the same for B. We do

--- a/en/11-functors-applicative-functors-and-monoids.md
+++ b/en/11-functors-applicative-functors-and-monoids.md
@@ -1869,7 +1869,7 @@ for the *data* keyword.
 Monoids
 -------
 
-![wow this is pretty much the gayest pirate ship ever](../img/pirateship.png)
+![pirate ship](../img/pirateship.png)
 
 Type classes in Haskell are used to present an interface for types that
 have some behavior in common. We started out with simple type classes

--- a/en/11-functors-applicative-functors-and-monoids.md
+++ b/en/11-functors-applicative-functors-and-monoids.md
@@ -30,7 +30,7 @@ of like socks.
 Functors redux
 --------------
 
-![frogs dont even need money](img/frogtor.png)
+![frogs dont even need money](../img/frogtor.png)
 
 We've already talked about functors in [their own little
 section](#the-functor-typeclass). If
@@ -128,7 +128,7 @@ main = do line <- fmap reverse getLine
           putStrLn $ "Yes, you really said" ++ line ++ " backwards!"
 ~~~~
 
-![w00ooOoooOO](img/alien.png)
+![w00ooOoooOO](../img/alien.png)
 
 Just like when we `fmap` `reverse` over `Just "blah"` to get `Just "halb"`, we
 can `fmap` `reverse` over `getLine`. `getLine` is an I/O action that has a type
@@ -276,8 +276,7 @@ computations than boxes (`IO` and `(->) r`) can be functors. The function
 being mapped over a computation results in the same computation but the
 result of that computation is modified with the function.
 
-![lifting a function is easier than lifting a million
-pounds](img/lifter.png)
+![lifting a function is easier than lifting a million pounds](../img/lifter.png)
 
 Before we go on to the rules that `fmap` should follow, let's think about
 the type of `fmap` once more. Its type is `fmap :: (a -> b) -> f a -> f b`.
@@ -406,8 +405,7 @@ Seeing that mapping `id` over a `Nothing` value returns the same value is
 trivial. So from these two equations in the implementation for `fmap`, we
 see that the law `fmap id = id` holds.
 
-![justice is blind, but so is my
-dog](img/justice.png)
+![justice is blind, but so is my dog](../img/justice.png)
 
 *The second law says that composing two functions and then mapping the
 resulting function over a functor should be the same as first mapping
@@ -577,7 +575,7 @@ three. This is what happens with composition.
 Applicative functors
 --------------------
 
-![disregard this analogy](img/present.png)
+![disregard this analogy](../img/present.png)
 
 In this section, we'll take a look at applicative functors, which are
 beefed up functors, represented in Haskell by the `Applicative` typeclass,
@@ -767,7 +765,7 @@ ghci> pure (+) <*> Nothing <*> Just 5
 Nothing
 ~~~~
 
-![whaale](img/whale.png)
+![whaale](../img/whale.png)
 
 What's going on here? Let's take a look, step by step. `<*>` is
 left-associative, which means that `pure (+) <*> Just 3 <*> Just 5`
@@ -978,7 +976,7 @@ instance Applicative IO where
         return (f x)
 ~~~~
 
-![ahahahah!](img/knight.png)
+![ahahahah!](../img/knight.png)
 
 Since `pure` is all about putting a value in a minimal context that still
 holds it as its result, it makes sense that `pure` is just `return`, because
@@ -1114,7 +1112,7 @@ ghci> (\x y z -> [x,y,z]) <$> (+3) <*> (*2) <*> (/2) $ 5
 [8.0,10.0,2.5]
 ~~~~
 
-![SLAP](img/jazzb.png)
+![SLAP](../img/jazzb.png)
 
 Same here. We create a function that will call the function
 `\x y z -> [x,y,z]` with the eventual results from `(+3)`, `(*2)` and `(/2)`.
@@ -1466,7 +1464,7 @@ semantics of each one.
 The newtype keyword
 -------------------
 
-![why\_ so serious?](img/maoi.png)
+![why\_ so serious?](../img/maoi.png)
 
 So far, we've learned how to make our own algebraic data types by using
 the *data* keyword. We've also learned how to give existing types
@@ -1632,7 +1630,7 @@ behaving like:
 fmap :: (a -> b) -> Maybe a -> Maybe b
 ~~~~
 
-![wow, very evil](img/krakatoa.png)
+![wow, very evil](../img/krakatoa.png)
 
 Isn't that just peachy? Now what if we wanted to make the tuple an
 instance of `Functor` in such a way that when we `fmap` a function over a
@@ -1772,7 +1770,7 @@ ghci> helloMe undefined
 "hello"
 ~~~~
 
-![top of the mornin to ya!!!](img/shamrock.png)
+![top of the mornin to ya!!!](../img/shamrock.png)
 
 It worked! Hmmm, why is that? Well, like we've said, when we use
 *newtype*, Haskell can internally represent the values of the new type
@@ -1871,8 +1869,7 @@ for the *data* keyword.
 Monoids
 -------
 
-![wow this is pretty much the gayest pirate ship
-ever](img/pirateship.png)
+![wow this is pretty much the gayest pirate ship ever](../img/pirateship.png)
 
 Type classes in Haskell are used to present an interface for types that
 have some behavior in common. We started out with simple type classes
@@ -1956,7 +1953,7 @@ class Monoid m where
     mconcat = foldr mappend mempty
 ~~~~
 
-![woof dee do!!!](img/balloondog.png)
+![woof dee do!!!](../img/balloondog.png)
 
 The `Monoid` type class is defined in `import Data.Monoid`. Let's take some
 time and get properly acquainted with it.
@@ -2049,7 +2046,7 @@ ghci> mempty :: [a]
 []
 ~~~~
 
-![smug as hell](img/smug.png)
+![smug as hell](../img/smug.png)
 
 Notice that in the last line, we had to write an explicit type
 annotation, because if we just did `mempty`, GHCi wouldn't know which
@@ -2270,7 +2267,7 @@ instance Monoid Ordering where
     GT `mappend` _ = GT
 ~~~~
 
-![did anyone ORDER pizza?!?! I can't BEAR these puns!](img/bear.png)
+![did anyone ORDER pizza?!?! I can't BEAR these puns!](../img/bear.png)
 
 The instance is set up like this: when we `mappend` two `Ordering` values,
 the one on the left is kept, unless the value on the left is `EQ`, in
@@ -2588,7 +2585,7 @@ instance F.Foldable Tree where
                              F.foldMap f r
 ~~~~
 
-![find the visual pun or whatever](img/accordion.png)
+![find the visual pun or whatever](../img/accordion.png)
 
 We think like this: if we are provided with a function that takes an
 element of our tree and returns a monoid value, how do we reduce our

--- a/en/12-a-fistful-of-monads.md
+++ b/en/12-a-fistful-of-monads.md
@@ -12,7 +12,7 @@ In this chapter, we'll learn about monads, which are just beefed up
 applicative functors, much like applicative functors are only beefed up
 functors.
 
-![more cool than u](img/smugpig.png)
+![more cool than u](../img/smugpig.png)
 
 When we started off with functors, we saw that it's possible to map
 functions over various data types. We saw that for this purpose, the
@@ -101,7 +101,7 @@ their behavior, but you'll see that it's easy as one two three.
 Getting our feet wet with Maybe
 -------------------------------
 
-![monads, grasshoppa](img/buddha.png)
+![monads, grasshoppa](../img/buddha.png)
 
 Now that we have a vague idea of what monads are about, let's see if we
 can make that idea a bit less vague.
@@ -273,7 +273,7 @@ class Monad m where
     fail msg = error msg
 ~~~~
 
-![this is you on monads](img/kid.png)
+![this is you on monads](../img/kid.png)
 
 Let's start with the first line. It says `class Monad m where`. But wait,
 didn't we say that monads are just beefed up applicative functors?
@@ -299,7 +299,7 @@ value. For `Maybe` it takes a value and wraps it in a `Just`.
 > languages. It doesn't end function execution or anything, it just takes
 > a normal value and puts it in a context.
 
-![hmmm yaes](img/tur2.png)
+![hmmm yaes](../img/tur2.png)
 
 The next function is `>>=`, or bind. It's like function application,
 only instead of taking a normal value and feeding it to a normal
@@ -362,7 +362,7 @@ it's `Nothing`, the result of using `>>=` will be `Nothing` as well.
 Walk the line
 -------------
 
-![pierre](img/pierre.png)
+![pierre](../img/pierre.png)
 
 Now that we know how to feed a `Maybe a` value to a function of type
 `a -> Maybe b` while taking into account the context of possible failure, let's
@@ -591,7 +591,7 @@ ghci> return (0,0) >>= landLeft 1 >>= landRight 4 >>= landLeft (-1) >>= landRigh
 Nothing
 ~~~~
 
-![iama banana](img/banana.png)
+![iama banana](../img/banana.png)
 
 Awesome. The final result represents failure, which is what we expected.
 Let's see how this result was obtained. First, `return` puts `(0,0)` into a
@@ -692,7 +692,7 @@ routine = case landLeft 1 (0,0) of
             Just pole3 -> landLeft 1 pole3
 ~~~~
 
-![john joe glanton](img/centaur.png)
+![john joe glanton](../img/centaur.png)
 
 We land a bird on the left and then we examine the possibility of
 failure and the possibility of success. In the case of failure, we
@@ -795,7 +795,7 @@ foo = do
     Just (show x ++ y)
 ~~~~
 
-![90s owl](img/owld.png)
+![90s owl](../img/owld.png)
 
 It would seem as though we've gained the ability to temporarily extract
 things from `Maybe` values without having to check if the `Maybe` values are
@@ -987,7 +987,7 @@ neat.
 The list monad
 --------------
 
-![dead cat](img/deadcat.png)
+![dead cat](../img/deadcat.png)
 
 So far, we've seen how `Maybe` values can be viewed as values with a
 failure context and how we can incorporate failure handling into our
@@ -1095,7 +1095,7 @@ ghci> [1,2] >>= \n -> ['a','b'] >>= \ch -> return (n,ch)
 [(1,'a'),(1,'b'),(2,'a'),(2,'b')]
 ~~~~
 
-![concatmap](img/concatmap.png)
+![concatmap](../img/concatmap.png)
 
 The list `[1,2]` gets bound to `n` and `['a','b']` gets bound to `ch`. Then, we
 do `return (n,ch)` (or `[(n,ch)]`), which means taking a pair of `(n,ch)` and
@@ -1268,7 +1268,7 @@ three moves. We'll just use a pair of numbers to represent the knight's
 position on the chess board. The first number will determine the column
 he's in and the second number will determine the row.
 
-![hee haw im a horse](img/chess.png)
+![hee haw im a horse](../img/chess.png)
 
 Let's make a type synonym for the knight's current position on the chess
 board:
@@ -1388,7 +1388,7 @@ it is now.
 Monad laws
 ----------
 
-![the court finds you guilty of peeing all over everything](img/judgedog.png)
+![the court finds you guilty of peeing all over everything](../img/judgedog.png)
 
 Just like applicative functors, and functors before them, monads come
 with a few laws that all monad instances must abide by. Just because

--- a/en/13-for-a-few-monads-more.md
+++ b/en/13-for-a-few-monads-more.md
@@ -1,9 +1,7 @@
 For a Few Monads More
 =====================
 
-![there are two kinds of people in the world, my friend. those who learn
-them a haskell and those who have the job of coding
-java](img/clint.png)
+![there are two kinds of people in the world, my friend. those who learn them a haskell and those who have the job of coding java](../img/clint.png)
 
 We've seen how monads can be used to take values with contexts and apply
 them to functions and how using `>>=` or `do` notation allows us to focus
@@ -72,8 +70,7 @@ ghci> isBigGang 30
 (True,"Compared gang size to 9.")
 ~~~~
 
-![when you have to poop, poop, don't
-talk](img/tuco.png)
+![when you have to poop, poop, don't talk](../img/tuco.png)
 
 So far so good. `isBigGang` takes a normal value and returns a value with
 a context. As we've just seen, feeding it a normal value is not a
@@ -278,8 +275,7 @@ instance (Monoid w) => Monad (Writer w) where
     (Writer (x,v)) >>= f = let (Writer (y, v')) = f x in Writer (y, v `mappend` v')
 ~~~~
 
-![when you have to poop, poop, don't
-talk](img/angeleyes.png)
+![when you have to poop, poop, don't talk](../img/angeleyes.png)
 
 First off, let's examine `>>=`. Its implementation is essentially the
 same as `applyLog`, only now that our tuple is wrapped in the
@@ -562,7 +558,7 @@ left instead of to the right.
 
 ### Difference lists
 
-![cactuses](img/cactus.png)
+![cactuses](../img/cactus.png)
 
 Because lists can sometimes be inefficient when repeatedly appended in
 this manner, it's best to use a data structure that always supports
@@ -734,7 +730,7 @@ head. Enjoy!
 Reader? Ugh, not this joke again.
 ---------------------------------
 
-![bang youre dead](img/revolver.png)
+![bang youre dead](../img/revolver.png)
 
 In the [chapter about
 applicatives](#functors-applicative-functors-and-monoids), we saw that
@@ -860,7 +856,7 @@ out.
 Tasteful stateful computations
 ------------------------------
 
-![don't jest with texas](img/texas.png)
+![don't jest with texas](../img/texas.png)
 
 Haskell is a pure language and because of that, our programs are made of
 functions that can't change any global state or variables, they can only
@@ -1044,7 +1040,7 @@ kept unchanged, because `return` has to put a value in a minimal context.
 So `return` will make a stateful computation that presents a certain value
 as the result and keeps the state unchanged.
 
-![im a cop](img/badge.png)
+![im a cop](../img/badge.png)
 
 What about `>>=`? Well, the result of feeding a stateful computation to
 a function with `>>=` has to be a stateful computation, right? So we
@@ -1389,7 +1385,7 @@ Let's see what they are then!
 
 ### liftM and friends
 
-![im a cop too](img/wolf.png)
+![im a cop too](../img/wolf.png)
 
 When we started our journey to the top of Monad Mountain, we first
 looked at functors, which are for things that can be mapped over. Then,
@@ -1664,7 +1660,7 @@ joinedMaybes = do
     m
 ~~~~
 
-![im a cop too as well also](img/tipi.png)
+![im a cop too as well also](../img/tipi.png)
 
 Perhaps the most interesting thing about `join` is that for every monad,
 feeding a monadic value to a function with `>>=` is the same thing as
@@ -1883,7 +1879,7 @@ your fold goes along its way.
 
 ### Making a safe RPN calculator
 
-![i've found yellow!](img/miner.png)
+![i've found yellow!](../img/miner.png)
 
 When we were solving the problem of [implementing a RPN
 calculator](#reverse-polish-notation-calculator), we noted that it worked
@@ -2124,7 +2120,7 @@ canReachIn x start end = end `elem` inMany x start
 Making monads
 -------------
 
-![kewl](img/spearhead.png)
+![kewl](../img/spearhead.png)
 
 In this section, we're going to look at an example of how a type gets
 made, identified as a monad and then given the appropriate `Monad`
@@ -2244,7 +2240,7 @@ likely to occur. Also, there's a 75% chance that exactly one of `'c'` or
 `'d'` will happen. `'c'` and `'d'` are also equally likely to happen. Here's a
 picture of a probability list that models this scenario:
 
-![probs](img/prob.png)
+![probs](../img/prob.png)
 
 What are the chances for each of these letters to occur? If we were to
 draw this as just four boxes, each with a probability, what would those
@@ -2293,7 +2289,7 @@ instance Monad Prob where
     fail _ = Prob []
 ~~~~
 
-![ride em cowboy](img/ride.png)
+![ride em cowboy](../img/ride.png)
 
 Because we already did all the hard work, the instance is very simple.
 We also defined the `fail` function, which is the same as it is for lists,

--- a/en/14-zippers.md
+++ b/en/14-zippers.md
@@ -1,7 +1,7 @@
 Zippers
 =======
 
-![hi im chet](img/60sdude.png)
+![hi im chet](../img/60sdude.png)
 
 While Haskell's purity comes with a whole bunch of benefits, it makes us
 tackle some problems differently than we would in impure languages.
@@ -71,7 +71,7 @@ freeTree =
 
 And here's this tree represented graphically:
 
-![polly says her back hurts](img/pollywantsa.png)
+![polly says her back hurts](../img/pollywantsa.png)
 
 Notice that `W` in the tree there? Say we want to change it into a `P`. How
 would we go about doing that? Well, one way would be to pattern match on
@@ -158,7 +158,7 @@ nearby.
 A trail of breadcrumbs
 ----------------------
 
-![whoop dee doo](img/bread.png)
+![whoop dee doo](../img/bread.png)
 
 Okay, so for focusing on a sub-tree, we want something better than just
 a list of directions that we always follow from the root of our tree.
@@ -202,7 +202,7 @@ ghci> goLeft (goRight (freeTree, []))
 (Node 'W' (Node 'C' Empty Empty) (Node 'R' Empty Empty),[L,R])
 ~~~~
 
-![almostthere](img/almostzipper.png)
+![almostthere](../img/almostzipper.png)
 
 Okay, so now we have a tree that has `'W'` in its root and `'C'` in the root
 of its left sub-tree and `'R'` in the root of its right sub-tree. The
@@ -316,7 +316,7 @@ goUp (t, LeftCrumb x r:bs) = (Node x t r, bs)
 goUp (t, RightCrumb x l:bs) = (Node x l t, bs)
 ~~~~
 
-![asstronaut](img/asstronaut.png)
+![asstronaut](../img/asstronaut.png)
 
 We're focusing on the tree `t` and we check what the latest `Crumb` is. If
 it's a `LeftCrumb`, then we construct a new tree where our tree `t` is the
@@ -455,7 +455,7 @@ we defined our data type like so:
 data List a = Empty | Cons a (List a) deriving (Show, Read, Eq, Ord)
 ~~~~
 
-![the best damn thing](img/picard.png)
+![the best damn thing](../img/picard.png)
 
 Contrast this with our definition of our binary tree and it's easy to
 see how lists can be viewed as trees where each node has only one
@@ -595,7 +595,7 @@ That's actually what my disk contains right now.
 
 ### A zipper for our file system
 
-![spongedisk](img/spongedisk.png)
+![spongedisk](../img/spongedisk.png)
 
 Now that we have a file system, all we need is a zipper so we can zip
 and zoom around it and add, modify and remove files as well as folders.
@@ -674,7 +674,7 @@ on the file with the given name. That file has to be in the current
 focused folder. This function doesn't search all over the place, it just
 looks at the current folder.
 
-![wow cool great](img/cool.png)
+![wow cool great](../img/cool.png)
 
 First we use `break` to break the list of items in a folder into those
 that precede the file that we're searching for and those that come after
@@ -784,7 +784,7 @@ goLeft :: Zipper a -> Zipper a
 goLeft (Node x l r, bs) = (l, LeftCrumb x r:bs)
 ~~~~
 
-![falling for you](img/bigtree.png)
+![falling for you](../img/bigtree.png)
 
 But what if the tree we're stepping off from is an empty tree? That is,
 what if it's not a `Node`, but an `Empty`? In this case, we'd get a runtime


### PR DESCRIPTION
Links were ```img/[image name].png```, but the img folder is in the directory above, so these links were broken.